### PR TITLE
Fix batch pool name

### DIFF
--- a/deploy/infra/create_cpu_batch_account_pool.bicep
+++ b/deploy/infra/create_cpu_batch_account_pool.bicep
@@ -19,7 +19,7 @@ param batchAccountPoolMountFileUrl string
 param acrName string = ''
 
 // Parameters with default values  for Data Fetch Batch Account Pool
-param batchAccountCpuOnlyPoolName string = 'data-cpu-pool'
+param batchAccountCpuOnlyPoolName string = '${environmentCode}-data-cpu-pool'
 param batchAccountCpuOnlyPoolVmSize string = 'standard_d2s_v3'
 param batchAccountCpuOnlyPoolDedicatedNodes int = 1
 param batchAccountCpuOnlyPoolImageReferencePublisher string = 'microsoft-azure-batch'

--- a/deploy/infra/groups/orchestration.bicep
+++ b/deploy/infra/groups/orchestration.bicep
@@ -80,7 +80,7 @@ param batchAccountPoolAllocationMode string = 'BatchService'
 param batchAccountPublicNetworkAccess bool = true
 
 // Parameters with default values  for Data Fetch Batch Account Pool
-param batchAccountCpuOnlyPoolName string = 'data-cpu-pool'
+param batchAccountCpuOnlyPoolName string = '${environmentCode}-data-cpu-pool'
 param batchAccountCpuOnlyPoolVmSize string = 'standard_d2s_v3'
 param batchAccountCpuOnlyPoolDedicatedNodes int = 1
 param batchAccountCpuOnlyPoolImageReferencePublisher string = 'microsoft-azure-batch'

--- a/deploy/package.py
+++ b/deploy/package.py
@@ -20,6 +20,7 @@ parser.add_argument('--synapse_workspace_id', type=str, required=True, help='Id 
 parser.add_argument('--synapse_workspace', type=str, required=True, help='Synapse pool name')
 parser.add_argument('--batch_storage_account_name', type=str, required=True, help='Name of the Batch Storage Account')
 parser.add_argument('--batch_account', type=str, required=True, help="Batch Account name")
+parser.add_argument('--batch_pool_name', type=str, required=True, help="Batch Pool name")
 parser.add_argument('--linked_key_vault', type=str, required=True, help="Key Vault to be added as Linked Service")
 parser.add_argument('--location', type=str, required=True, help="Batch Account Location")
 parser.add_argument('--pipeline_name', type=str, required=True, help="Name of the pipeline to package")
@@ -146,6 +147,7 @@ if __name__ == "__main__":
         '__raw_data_storage_account__': args.raw_storage_account_name,
         '__batch_storage_account__': args.batch_storage_account_name,
         '__batch_account__': args.batch_account,
+        '__batch_pool_name__': args.batch_pool_name,
         '__linked_key_vault__': args.linked_key_vault,
         '__synapse_storage_account__': args.synapse_storage_account_name,
         '__synapse_pool_name__': args.synapse_pool_name,

--- a/deploy/package.sh
+++ b/deploy/package.sh
@@ -92,6 +92,7 @@ if [[ "$AI_MODEL_INFRA_TYPE" == "batch-account" ]]; then
         --modes $MODE \
         --batch_storage_account_name $BATCH_STORAGE_ACCOUNT_NAME \
         --batch_account $BATCH_ACCOUNT_NAME \
+        --batch_pool_name ${ENV_CODE}-data-cpu-pool \
         --linked_key_vault $KEY_VAULT_NAME \
         --synapse_pool_name $SYNAPSE_POOL \
         --location $BATCH_ACCOUNT_LOCATION \

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -9,7 +9,7 @@ PIPELINE_NAME=${3:-${PIPELINE_NAME}}
 ENV_TAG=${4:-${ENV_TAG}}
 PRE_PROVISIONED_AI_MODEL_INFRA_NAME=${5:-$PRE_PROVISIONED_AI_MODEL_INFRA_NAME}
 AI_MODEL_INFRA_TYPE=${6:-${AI_MODEL_INFRA_TYPE:-"batch-account"}} # Currently supported values are aks and batch-account
-DEPLOY_PGSQL=${7:-${DEPLOY_PGSQL:-"true"}}
+DEPLOY_PGSQL=${7:-${DEPLOY_PGSQL:-"false"}}
 
 set -ex
 

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -9,7 +9,7 @@ PIPELINE_NAME=${3:-${PIPELINE_NAME}}
 ENV_TAG=${4:-${ENV_TAG}}
 PRE_PROVISIONED_AI_MODEL_INFRA_NAME=${5:-$PRE_PROVISIONED_AI_MODEL_INFRA_NAME}
 AI_MODEL_INFRA_TYPE=${6:-${AI_MODEL_INFRA_TYPE:-"batch-account"}} # Currently supported values are aks and batch-account
-DEPLOY_PGSQL=${7:-${DEPLOY_PGSQL:-"false"}}
+DEPLOY_PGSQL=${7:-${DEPLOY_PGSQL:-"true"}}
 
 set -ex
 

--- a/src/workflow/custom-vision-model-v2/linkedService/AOI Batch.json
+++ b/src/workflow/custom-vision-model-v2/linkedService/AOI Batch.json
@@ -5,7 +5,7 @@
         "type": "AzureBatch",
         "typeProperties": {
             "batchUri": "https://__batch_account__.__location__.batch.azure.com",
-            "poolName": "data-cpu-pool",
+            "poolName": "__batch_pool_name__",
             "accountName": "__batch_account__",
             "linkedServiceName": {
                 "referenceName": "AOI Batch Storage",

--- a/src/workflow/custom-vision-model/linkedService/AOI Batch.json
+++ b/src/workflow/custom-vision-model/linkedService/AOI Batch.json
@@ -5,7 +5,7 @@
         "type": "AzureBatch",
         "typeProperties": {
             "batchUri": "https://__batch_account__.__location__.batch.azure.com",
-            "poolName": "data-cpu-pool",
+            "poolName": "__batch_pool_name__",
             "accountName": "__batch_account__",
             "linkedServiceName": {
                 "referenceName": "AOI Batch Storage",


### PR DESCRIPTION
Currently, when provisioning the batch account, the pool name has been created as `data-cpu-pool`. However, during the creation of the batch job, the pool name is passed with the environment code prefixed. As a result, the batch job is created with a pool name that doesn't exist. This PR fixes the batch pool name to include the environment code as a prefix during creation. 

For the record, I have tested this PR with a new batch account and a pre-provisioned batch account; in both cases, the pool name is created with a prefixed environment code. Also, the JSON files have been corrected accordingly. 

Additionally, changed the default value to false for PG deployment. 