### PR TITLE
Move sample image location

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
-
 # Declare *.sh files that will always have LF line endings on checkout.
 *.sh text eol=lf
+*.tif filter=lfs diff=lfs merge=lfs -text
+*.tiff filter=lfs diff=lfs merge=lfs -text

--- a/deploy/sample_data/sample_4326.tif
+++ b/deploy/sample_data/sample_4326.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d40bc74ce9ffe93ff54e4fc6b3c4e0c687584a356a87060dda646b8fd59dfd0
+size 502132710

--- a/deploy/scripts/copy_geotiff.sh
+++ b/deploy/scripts/copy_geotiff.sh
@@ -35,7 +35,7 @@ export AZURE_STORAGE_AUTH_MODE
 declare -A array
 
 key1='sample_4326.tif'
-value1='https://aoigeospatial.blob.core.windows.net/public/samples/sample_4326.tif'
+value1='https://raw.githubusercontent.com/Azure/Azure-Orbital-Analytics-Samples/main/deploy/sample_data/sample_4326.tif'
 
 key2='custom_vision_object_detection.json'
 value2='https://raw.githubusercontent.com/Azure/Azure-Orbital-Analytics-Samples/main/src/aimodels/custom_vision_object_detection_offline/specs/custom_vision_object_detection.json'


### PR DESCRIPTION
Move the sample GeoTiff file from the public storage account to be part of the repo. This is required to prevent users having public access to storage accounts. 

By default, GH limits file size to 100 MB. In this case, the sample file is ~480 MB which gets rejected during git push. I have used git-lfs (large file storage), an extension of GH, to handle this scenario. LFS stores the file content on a remote GH server and only a pointer on the git repo. For more info, visit https://git-lfs.github.com/ 